### PR TITLE
Add Fed rate data loader and engineered rate features

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,7 +5,7 @@ to make decisions on investments.
 
 - This is a supervised learning multi- regression problem using batch processing. 
 
-- Will use root mean squared error as the metric to evaluate the model. 
+- Will use root mean squared error as the metric to evaluate the model and it fits the business objective because this is a regression model and it will determine errors in predictions. 
 
 - The Effective Federal Reserve Interest Rate is the average of the federal reserve interest rate over the past 12 months. 
 
@@ -20,8 +20,6 @@ to make decisions on investments.
     -   Federal Funds Target Rate (the primary policy tool being predicted)
     -   Federal Funds Upper and Lower Target (the boundaries set by the Fed for the effective rate)
     -   Time Period (Year, Month, and Day for time-series analysis)
-
-
 
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from dotenv import load_dotenv
+import numpy as np
+import pandas as pd
+import kagglehub
+
+load_dotenv()
+
+
+def load_interest_rate_data() -> pd.DataFrame:
+    """
+    Download the Federal Reserve interest rates dataset via kagglehub
+    and return a concatenated DataFrame of all CSV files in the package.
+    """
+    print("Downloading dataset...")
+    dataset_dir = Path(kagglehub.dataset_download("federalreserve/interest-rates"))
+    print(f"Dataset directory: {dataset_dir}")
+    csv_files = sorted(dataset_dir.glob("*.csv"))
+    if not csv_files:
+        raise FileNotFoundError(f"No CSV files found in {dataset_dir}")
+
+    frames = []
+    for csv_path in csv_files:
+        df = pd.read_csv(csv_path)
+        # Track origin file so it's easy to filter/inspect by source.
+        df["source_file"] = csv_path.name
+        frames.append(df)
+
+    return pd.concat(frames, ignore_index=True)
+
+
+def shuffle_and_split_data(data, test_ratio):
+    shuffled_indices = np.random.permutation(len(data))
+    test_set_size = int(len(data) * test_ratio)
+    test_indices = shuffled_indices[:test_set_size]
+    train_indices = shuffled_indices[test_set_size:]
+    return data.iloc[train_indices], data.iloc[test_indices]
+
+
+def add_rate_category(df: pd.DataFrame, col: str = "Effective Federal Funds Rate") -> pd.DataFrame:
+    """
+    Add a categorical 'rate_cat' column for stratified sampling on a rate column.
+    Bins cover the historical range (~0–20%) while keeping strata large enough.
+    """
+    bins = [-0.01, 1, 2, 3, 4, 5, 7.5, 10, 15, np.inf]
+    labels = range(1, len(bins))
+    df = df.copy()
+    if col not in df.columns:
+        raise KeyError(f"Column '{col}' not found in DataFrame")
+    df["rate_cat"] = pd.cut(df[col], bins=bins, labels=labels)
+    return df

--- a/train_interest_rate_model.py
+++ b/train_interest_rate_model.py
@@ -1,0 +1,71 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from helper_functions import load_interest_rate_data
+from sklearn.model_selection import train_test_split
+from sklearn.model_selection import TimeSeriesSplit
+from pandas.plotting import scatter_matrix
+
+# Get data once
+data = load_interest_rate_data().copy()
+
+# Basic look if needed
+# print(data.head())
+# print(data.info())
+# print(data.describe())
+
+# Build a proper datetime from Year/Month/Day
+data["Day"] = data["Day"].fillna(1).astype(int)
+data["date"] = pd.to_datetime(dict(year=data["Year"], month=data["Month"], day=data["Day"]), errors="coerce")
+data = data.sort_values("date")
+
+# Feature engineering (similar style to rooms_per_house, etc.)
+# Fill missing upper/lower targets with target rate, then effective rate as last resort.
+upper = (
+    data["Federal Funds Upper Target"]
+    .fillna(data["Federal Funds Target Rate"])
+    .fillna(data["Effective Federal Funds Rate"])
+)
+lower = (
+    data["Federal Funds Lower Target"]
+    .fillna(data["Federal Funds Target Rate"])
+    .fillna(data["Effective Federal Funds Rate"])
+)
+
+data["rate_spread"] = (upper - lower).fillna(0)
+data["implementation_gap"] = (data["Effective Federal Funds Rate"] - upper).fillna(0)
+data["real_ffr"] = data["Effective Federal Funds Rate"] - data["Inflation Rate"]
+
+train_set, test_set = train_test_split(data, test_size=0.2, shuffle=False)
+train_set = train_set.drop(columns=["date"])
+test_set  = test_set.drop(columns=["date"])
+
+
+#Cross validation
+
+# tscv = TimeSeriesSplit(n_splits=5)
+# for train_idx, test_idx in tscv.split(data):
+#     train_fold = data.iloc[train_idx]
+#     test_fold  = data.iloc[test_idx]
+#     # fit/evaluate here
+
+train_set_copy = train_set.copy()
+
+# Correlation on numeric columns only (avoid 'source_file' strings)
+numeric_cols = train_set_copy.select_dtypes(include=[np.number])
+corr_matrix = numeric_cols.corr()
+print(corr_matrix["Federal Funds Target Rate"].sort_values(ascending=False))
+
+# attributes = ["Federal Funds Target Rate", "Effective Federal Funds Rate", "Inflation Rate",
+#               "Unemployment Rate"]
+# scatter_matrix(train_set_copy[attributes], figsize=(12, 8))
+# plt.show()
+
+
+# train_set_copy.plot(kind="scatter", x="Federal Funds Target Rate", y="Inflation Rate",
+#              alpha=0.1, grid=True)
+# plt.show()
+
+
+Stoped at Prepare the Data for Machine Learning Algorithms. Pretty fun so far!


### PR DESCRIPTION
## Summary
- download/caches federalreserve/interest-rates via kagglehub
- build datetime, chronological train/test split, and new rate features (spread, implementation gap, real FFR)
- minor analysis helpers retained

## Testing
- not run (data download only)